### PR TITLE
feat(tagsInput): Add onTagClicked callback

### DIFF
--- a/src/tags-input.js
+++ b/src/tags-input.js
@@ -34,6 +34,7 @@
  *                                                   allowLeftoverText values are ignored.
  * @param {expression} onTagAdded Expression to evaluate upon adding a new tag. The new tag is available as $tag.
  * @param {expression} onTagRemoved Expression to evaluate upon removing an existing tag. The removed tag is available as $tag.
+ * @param {expression} onTagClicked Expression to evaluate upon clicking an existing tag. The clicked tag is available as $tag.
  */
 tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) {
     function TagList(options, events) {
@@ -85,7 +86,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
             return tag;
         };
 
-        self.remove = function(index) {
+        self.remove = function(index, event) {
+            if (event) { event.stopPropagation(); }
             var tag = self.items.splice(index, 1)[0];
             events.trigger('tag-removed', { $tag: tag });
             return tag;
@@ -105,6 +107,11 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
             return tag;
         };
 
+        self.tagClick = function(index) {
+            var tag = self.items[index];
+            events.trigger('tag-clicked', { $tag: tag });
+        };
+
         return self;
     }
 
@@ -118,7 +125,8 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
         scope: {
             tags: '=ngModel',
             onTagAdded: '&',
-            onTagRemoved: '&'
+            onTagRemoved: '&',
+            onTagClicked: '&'
         },
         replace: false,
         transclude: true,
@@ -196,6 +204,7 @@ tagsInput.directive('tagsInput', function($timeout, $document, tagsInputConfig) 
             events
                 .on('tag-added', scope.onTagAdded)
                 .on('tag-removed', scope.onTagRemoved)
+                .on('tag-clicked', scope.onTagClicked)
                 .on('tag-added', function() {
                     scope.newTag.text = '';
                 })

--- a/templates/tags-input.html
+++ b/templates/tags-input.html
@@ -1,9 +1,9 @@
 <div class="host" tabindex="-1" ti-transclude-append>
   <div class="tags" ng-class="{focused: hasFocus}">
     <ul class="tag-list">
-      <li class="tag-item" ng-repeat="tag in tagList.items track by track(tag)" ng-class="{ selected: tag == tagList.selected }">
+      <li class="tag-item" ng-repeat="tag in tagList.items track by track(tag)" ng-class="{ selected: tag == tagList.selected }" ng-click="tagList.tagClick($index)">
         <span ng-bind="getDisplayText(tag)"></span>
-        <a class="remove-button" ng-click="tagList.remove($index)" ng-bind="options.removeTagSymbol"></a>
+        <a class="remove-button" ng-click="tagList.remove($index, $event)" ng-bind="options.removeTagSymbol"></a>
       </li>
     </ul>
     <input class="input"

--- a/test/tags-input.spec.js
+++ b/test/tags-input.spec.js
@@ -180,6 +180,21 @@ describe('tags-input directive', function() {
             expect($scope.tags).toEqual([{ text: 'Tag1' }, { text: 'Tag3' }]);
         });
 
+        it('invokes a click event when a tag is clicked', function() {
+            // Arrange
+            $scope.tags = generateTags(3);
+            $scope.setClickedTag = function(tag) {
+                $scope.clickedTag = tag;
+            };
+            compile('on-tag-clicked="setClickedTag($tag)"');
+
+            // Act
+            getTag(1).click();
+
+            // Assert
+            expect($scope.clickedTag).toEqual({ text: 'Tag2' });
+        });
+
         it('sets focus on the input field when the container div is clicked', function() {
             // Arrange
             compile();


### PR DESCRIPTION
Add an option for the user to set a callback in case a tag was clicked.
This feature is important because it allows the user to implement a filtering mechanism
of a list of tagged items by a specific tag when a tag is clicked.

No open issue.
